### PR TITLE
Changed the way of calculating Content-length header for http request with Express

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -132,7 +132,7 @@ httpClient.prototype = {
     var headers = {
       'Authorization': self._root._api['auth'],
       'Content-Type': 'application/json',
-      'Content-Length': requestData.length,
+      'Content-Length': Buffer.byteLength(requestData),
       'User-Agent': '@Larafale'
     }
 


### PR DESCRIPTION
Content-Length header should be calculated like this:

```
'Content-Length': Buffer.byteLength(requestData, 'utf-8')
```

As per https://github.com/strongloop/express/issues/1870

If this is not changed, errors are thrown when using non-ASCII characters.
