### PR TITLE
Removing `BIC` from required `mango.bank.wire` params

### DIFF
--- a/resources/bank.js
+++ b/resources/bank.js
@@ -41,7 +41,6 @@ module.exports = httpClient.extend({
         , 'DebitedFunds': { required: true }
         , 'Fees': { required: true, default: { Currency: 'EUR', Amount: 0 } }
         , 'BankAccountId': { required: true }
-        , 'BIC': { required: true }
       }
     }),
 


### PR DESCRIPTION
In the docs it doesn't seem to be required or mentioned: http://docs.mangopay.com/api-references/pay-out-bank-wire/
