### PR TITLE
no need for BIC for type:IBAN

### DIFF
--- a/resources/bank.js
+++ b/resources/bank.js
@@ -19,7 +19,6 @@ module.exports = httpClient.extend({
         , 'Type': { required: true, default: 'IBAN' }
         , 'OwnerAddress': { required: true }
         , 'IBAN': { required: true }
-        , 'BIC': { required: true }
       }
     }),
 


### PR DESCRIPTION
https://docs.mangopay.com/api-references/bank-accounts/