### PR TITLE
Removed IBAN and UserId from required params in bank.create method

### DIFF
--- a/resources/bank.js
+++ b/resources/bank.js
@@ -15,10 +15,8 @@ module.exports = httpClient.extend({
       path: '{UserId}/bankaccounts/{Type}',
       params: {
           'OwnerName': { required: true }
-        , 'UserId': { required: true }
         , 'Type': { required: true, default: 'IBAN' }
         , 'OwnerAddress': { required: true }
-        , 'IBAN': { required: true }
       }
     }),
 


### PR DESCRIPTION
UserId is not required and IBAN is required only if the Type field is 'IBAN'. If you use another Type the validation fails.