### PR TITLE
increasing timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function Mango(options){
     host: 'api.sandbox.mangopay.com',
     port: '',
     basePath: '/v2/' + this._options.username,
-    timeout: 30 * 1000
+    timeout: 120 * 1000
   }
 
   if(this._options.production)


### PR DESCRIPTION
I have been getting quite a few timeout errors and my internet is pretty fast.
I believe this happens because mangopay has to comunicate with a bunch of high security services that take their time.