### PR TITLE
Updating documentation for user.signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Create natural user and wallet:
       PersonType: "NATURAL", 
       Email: "victor@hugo.com", 
       Tag: "custom tag",
-    }, function(err, wallet, res){
+    }, function(err, user, wallet){
         console.log('err', err);
+        console.log('user', user);
         console.log('wallet', wallet);
-        console.log('res', res.statusCode);
     });
 ```
 


### PR DESCRIPTION
Documentation was incorrect for `mango.user.signup`. The parameters returned are `err, user, wallet`. `res` is lost here as two requests are being made. Which isn't really a problem anyway as errors are handled by the library,