### PR TITLE
also return `data` and `res` when request gets an error

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -64,8 +64,8 @@ httpClient.prototype = {
         // (Ensure callback is called outside of promise stack)
         deferred.promise.then(function(data){
           setTimeout(function(){ callback(null, data[0], data[1]) }, 0)
-        }, function(err){
-          setTimeout(function(){ callback(err, null) }, 0)
+        }, function(data){
+          setTimeout(function(){ callback(data[0] /* err */, data[1] /* data */, data[2] /* res */) }, 0)
         })
       }
 

--- a/lib/httpMethod.js
+++ b/lib/httpMethod.js
@@ -21,7 +21,7 @@ var httpMethod = module.exports = function httpMethod(spec, middleware){
   var middleware = middleware || null
 
   return function(){
-  
+
     var self = this
     var args = [].slice.call(arguments)
     var callback = typeof args[args.length - 1] == 'function' && args.pop()
@@ -52,8 +52,8 @@ var httpMethod = module.exports = function httpMethod(spec, middleware){
         middleware.call(
             self
           , err
-          , data && !err
-              ? spec.transformResponseData 
+          , data
+              ? spec.transformResponseData
                 ? spec.transformResponseData(data)
                 : data
               : null
@@ -63,9 +63,15 @@ var httpMethod = module.exports = function httpMethod(spec, middleware){
         )
       }else{
         err
-          ? deferred.reject(err)
+          ? deferred.reject([
+              err,
+              spec.transformResponseData
+                ? spec.transformResponseData(data)
+                : data
+              , res
+            ])
           : deferred.resolve([
-              spec.transformResponseData 
+              spec.transformResponseData
                 ? spec.transformResponseData(data)
                 : data
               , res


### PR DESCRIPTION
I am running into the issue where I fetch a FAILED payIn from Mangopay. In that case, the module only returns the following error:

```
{ [MangoPayError: Unknow error code]
  name: 'MangoPayError',
  message: 'Unknow error code',
  code: '001034' }
```

The problem is, I need to know the actual payload that Mangopay API also returns with this error, so that I can update my own application's state. The module currently strips out this payload in case of an error. This PR undoes that.