### PR TITLE
Allow to fetch KYC Documents without UserId

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,41 @@ Get wire:
   * `addFile(params)`
   * `fetch(params)`
   * `update(params)`
+
+Get document with userId: 
+
+```js
+    mango.document.fetch({ 
+      UserId: '12567875',   // Required
+      Id: '2568348',        // Required
+    }, function(err, document, res){
+        console.log('err', err);
+        console.log('document', document);
+        console.log('res', res.statusCode);
+    })
+```
+
+* kyc
+
+Get document with its own id (without userId): 
+```js
+    mango.kyc.fetch({ 
+      Id: '2568348', // Required
+    }, function(err, document, res){
+        console.log('err', err);
+        console.log('document', document);
+        console.log('res', res.statusCode);
+    })
+```
+
+List all KYC documents: 
+```js
+    mango.kyc.list(function(err, documents, res){
+        console.log('err', err);
+        console.log('documents', documents);
+        console.log('res', res.statusCode);
+    })
+```
   
 * payin
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function Mango(options){
     this._api.host = 'api.mangopay.com'
 
   // mount endpoints
-  this.mount(this._options.mount || 'user|card|wallet|author|bank|document|payin|hook|event')
+  this.mount(this._options.mount || 'user|card|wallet|author|bank|document|kyc|payin|hook|event')
 
   // set auth
   this.setAuth(options)

--- a/resources/kyc.js
+++ b/resources/kyc.js
@@ -1,0 +1,33 @@
+
+var httpClient = require('../lib/httpClient')
+  , httpMethod = require('../lib/httpMethod')
+
+
+module.exports = httpClient.extend({
+  // The document resource fetches documents based on UserId.
+  // But sometimes, you want to fetch documents by their Id, without UserId.
+  // That's why this 'kyc' resource exists.
+  path: 'kyc/documents',
+  
+  methods: {
+
+    /*
+      See: https://docs.mangopay.com/endpoints/v2.01/kyc-documents#e207_view-a-kyc-document
+    */
+    fetch: httpMethod({
+      method: 'GET',
+      path: '{Id}',
+      requiredParams: ['Id'],
+    })
+
+    /*
+      See: https://docs.mangopay.com/endpoints/v2.01/kyc-documents#e217_list-all-kyc-documents
+    */
+    list: httpMethod({
+      method: 'GET',
+      path: '',
+    }),
+  
+  }
+
+})

--- a/resources/kyc.js
+++ b/resources/kyc.js
@@ -8,6 +8,8 @@ module.exports = httpClient.extend({
   // But sometimes, you want to fetch documents by their Id, without UserId.
   // That's why this 'kyc' resource exists.
   path: 'kyc/documents',
+      
+  includeBasic: [ 'list' ], // See: https://docs.mangopay.com/endpoints/v2.01/kyc-documents#e217_list-all-kyc-documents
   
   methods: {
 
@@ -20,14 +22,6 @@ module.exports = httpClient.extend({
       requiredParams: ['Id'],
     })
 
-    /*
-      See: https://docs.mangopay.com/endpoints/v2.01/kyc-documents#e217_list-all-kyc-documents
-    */
-    list: httpMethod({
-      method: 'GET',
-      path: '',
-    }),
-  
   }
 
 })


### PR DESCRIPTION
I needed to fetch KYC Documents without the UserId who owns the document. I've just added a kyc resource (maybe not the best name).
Doc: https://docs.mangopay.com/endpoints/v2.01/kyc-documents#e207_view-a-kyc-document

Regards.